### PR TITLE
@W-8306895@ For MongoDB TLS auth, allow ignoring of invalid hostnames + Java driver upgrade

### DIFF
--- a/.strata.yml
+++ b/.strata.yml
@@ -1,0 +1,11 @@
+pipeline_template: jar/Jenkinsfile-1
+email_reply_to: mc-hypergage@salesforce.com
+time_out_mins: 180                                    # (Optional) default shown
+number_of_artifacts_to_keep: 3                        # (Optional) default shown
+compliance_required: false                             # (Optional) default shown
+docker_test_images:
+   - dva/sfdc_centos7_java8_build
+unit_tests_command: echo "no tests included"
+production_branch:
+    - 1.6.5.x
+publish_jar_image: dva/sfdc_centos7_java8_build_hypergage

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+#GUSINFO:MCIS - Operations Team,MCIS Operations
+*

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
+            <artifactId>mongodb-driver</artifactId>
             <version>${mongo-java-driver.version}</version>
         </dependency>        
     </dependencies>
@@ -55,7 +55,7 @@
         </plugins>
     </build>
     <properties>
-        <mongo-java-driver.version>3.2.2</mongo-java-driver.version>
+        <mongo-java-driver.version>3.8.3-evg3</mongo-java-driver.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.evergage.thirdparty.mongodb</groupId>
+            <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
             <version>${mongo-java-driver.version}</version>
         </dependency>        
@@ -56,7 +56,7 @@
         </plugins>
     </build>
     <properties>
-        <mongo-java-driver.version>3.8.3-evg3</mongo-java-driver.version>
+        <mongo-java-driver.version>3.12.8</mongo-java-driver.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,10 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.astral303</groupId>
+    <groupId>com.evergage.thirdparty.mongo-store</groupId>
     <artifactId>mongo-store</artifactId>
-    <version>1.6.5.1</version>
+    <version>1.6.5-evg2</version>
+
     <licenses>
         <license>
             <name>Apache 2</name>
@@ -22,8 +23,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.mongodb</groupId>
-            <artifactId>mongodb-driver</artifactId>
+            <groupId>com.evergage.thirdparty.mongodb</groupId>
+            <artifactId>mongo-java-driver</artifactId>
             <version>${mongo-java-driver.version}</version>
         </dependency>        
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.evergage.thirdparty.mongo-store</groupId>
     <artifactId>mongo-store</artifactId>
-    <version>1.6.5-evg3</version>
+    <version>1.6.5-evg4</version>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina</artifactId>
-            <version>7.0.104</version>
+            <version>7.0.108</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.astral303</groupId>
     <artifactId>mongo-store</artifactId>
-    <version>1.6.5</version>
+    <version>1.6.5.1</version>
     <licenses>
         <license>
             <name>Apache 2</name>
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina</artifactId>
-            <version>7.0.68</version>
+            <version>7.0.104</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>
@@ -35,8 +35,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.evergage.thirdparty.mongo-store</groupId>
     <artifactId>mongo-store</artifactId>
-    <version>1.6.5-evg2</version>
+    <version>1.6.5-evg3</version>
 
     <licenses>
         <license>

--- a/src/main/java/com/dawsonsystems/session/ClientSSLFromPEMsUtility.java
+++ b/src/main/java/com/dawsonsystems/session/ClientSSLFromPEMsUtility.java
@@ -1,0 +1,154 @@
+package com.dawsonsystems.session;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import javax.security.auth.x500.X500Principal;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+/**
+ * SSLContext that uses certificates from PEM-based CA bundles and client private keys from PEM bundles.
+ */
+class ClientSSLFromPEMsUtility {
+
+    /**
+     * Create an SSL context suitable for client authentication and using a specific trust store.
+     *
+     * @param serverTrustStorePem   path to a bundle of certificate PEMs, which will be trusted by this context
+     * @param combinedCertAndKeyPem path to a combined PEM file, containing client private key (unencrypted) and certs
+     */
+    public static SSLContextResponse sslContextFromPEMs(File serverTrustStorePem, File combinedCertAndKeyPem) {
+        if (!serverTrustStorePem.canRead()) {
+            throw new IllegalArgumentException("Unable to read server trust store PEM: " + serverTrustStorePem);
+        }
+
+        if (!combinedCertAndKeyPem.canRead()) {
+            throw new IllegalArgumentException("Unable to read combined cert and key PEM: " + combinedCertAndKeyPem);
+        }
+
+        try {
+            KeyStore trustStore = createTrustStoreFromPEMBundle(serverTrustStorePem);
+            TrustManagerFactory trustManagerFactory =
+                    TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(trustStore);
+
+            // Default to using PEM filename for cert key
+            String keyAlias = combinedCertAndKeyPem.getName();
+
+            KeyStore keystore = createKeyStoreFromCombinedPEM(combinedCertAndKeyPem, keyAlias);
+            KeyManagerFactory keyManagerFactory =
+                    KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            keyManagerFactory.init(keystore, "".toCharArray());
+
+            X500Principal subjectPrincipal = ((X509Certificate) keystore.getCertificate(keyAlias)).getSubjectX500Principal();
+
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null);
+            return new SSLContextResponse(sslContext, subjectPrincipal);
+        } catch (GeneralSecurityException | IOException e) {
+            throw new IllegalArgumentException(
+                    "Failed to read certificates from combined cert and key PEM " + combinedCertAndKeyPem, e);
+        }
+    }
+
+    private static KeyStore createKeyStoreFromCombinedPEM(File combinedCertAndKeyPem, String alias)
+            throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException,
+            InvalidKeySpecException {
+        X509Certificate[] clientCertificateChain = parseX509CertificatesFromPEMBundle(combinedCertAndKeyPem);
+        PrivateKey clientKey = parsePrivateKeyFromPEM(combinedCertAndKeyPem);
+
+        KeyStore keystore = KeyStore.getInstance("JKS");
+        keystore.load(null);
+
+        keystore.setKeyEntry(alias, clientKey, "".toCharArray(), clientCertificateChain);
+        return keystore;
+    }
+
+    private static KeyStore createTrustStoreFromPEMBundle(File serverTrustStorePem)
+            throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
+        KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        trustStore.load(null, null);
+
+        X509Certificate[] certsFromStore = parseX509CertificatesFromPEMBundle(serverTrustStorePem);
+        for (int i = 0; i < certsFromStore.length; i++) {
+            X509Certificate x509Certificate = certsFromStore[i];
+            trustStore.setCertificateEntry("trusted_cert_" + i, x509Certificate);
+        }
+        return trustStore;
+    }
+
+    private static PrivateKey parsePrivateKeyFromPEM(File privateKeyPem)
+            throws IOException, InvalidKeySpecException, NoSuchAlgorithmException {
+        String privateKeyPemText = new String(Files.readAllBytes(privateKeyPem.toPath()));
+
+        Matcher keyMatcher = Pattern.compile(".*BEGIN PRIVATE KEY-+\n(.+?)\n-+END PRIVATE KEY.*", Pattern.DOTALL)
+                .matcher(privateKeyPemText);
+
+        if (!keyMatcher.matches()) {
+            throw new IllegalArgumentException("Failed to find private key in source PEM " + privateKeyPem);
+        }
+
+        byte[] bytes = Base64.getMimeDecoder().decode(keyMatcher.group(1));
+        return KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(bytes));
+    }
+
+
+    private static X509Certificate[] parseX509CertificatesFromPEMBundle(File certificatePem) throws IOException,
+            CertificateException {
+        String certificatePemText = new String(Files.readAllBytes(certificatePem.toPath()));
+
+        Matcher certMatcher = Pattern.compile("BEGIN CERTIFICATE-+\n(.+?)\n-+END CERTIFICATE", Pattern.DOTALL)
+                .matcher(certificatePemText);
+
+        List<X509Certificate> results = new ArrayList<>();
+
+        while (certMatcher.find()) {
+            String certBase64 = certMatcher.group(1);
+            byte[] bytes = Base64.getMimeDecoder().decode(certBase64);
+            results.add((X509Certificate)
+                                CertificateFactory.getInstance("X.509")
+                                        .generateCertificate(new ByteArrayInputStream(bytes)));
+        }
+
+        return results.toArray(new X509Certificate[0]);
+    }
+
+
+    static class SSLContextResponse {
+        public final SSLContext sslContext;
+        public final X500Principal subjectPrincipal;
+
+        public SSLContextResponse(SSLContext sslContext, X500Principal certificateSubject) {
+            this.sslContext = sslContext;
+            this.subjectPrincipal = certificateSubject;
+        }
+    }
+
+    public static void main(String[] args) {
+        SSLContextResponse contextResponse =
+                ClientSSLFromPEMsUtility.sslContextFromPEMs(new File(args[0]), new File(args[1]));
+        System.out.println("Subject received: " + contextResponse.subjectPrincipal.getName("RFC2253"));
+    }
+}
+
+

--- a/src/main/java/com/dawsonsystems/session/MongoManager.java
+++ b/src/main/java/com/dawsonsystems/session/MongoManager.java
@@ -65,6 +65,7 @@ public class MongoManager implements Manager, Lifecycle {
   // Mongo client SSL support directly from PEM bundles
   private String sslKeyStorePem;
   private String sslTrustStorePem;
+  private boolean sslInvalidHostNameAllowed;
 
   @Override
   public Container getContainer() {
@@ -198,6 +199,14 @@ public class MongoManager implements Manager, Lifecycle {
 
   public void setSslTrustStorePem(String sslTrustStorePem) {
     this.sslTrustStorePem = sslTrustStorePem;
+  }
+
+  public boolean isSslInvalidHostNameAllowed() {
+    return sslInvalidHostNameAllowed;
+  }
+
+  public void setSslInvalidHostNameAllowed(boolean sslInvalidHostNameAllowed) {
+    this.sslInvalidHostNameAllowed = sslInvalidHostNameAllowed;
   }
 
   public void load() throws ClassNotFoundException, IOException {
@@ -556,6 +565,7 @@ public class MongoManager implements Manager, Lifecycle {
         SSLContext sslContext = sslContextFromPEMs(new File(sslTrustStorePem), new File(sslKeyStorePem));
         clientOptionsBuilder.sslEnabled(true);
         clientOptionsBuilder.sslContext(sslContext);
+        clientOptionsBuilder.sslInvalidHostNameAllowed(sslInvalidHostNameAllowed);
         mongoCredentials.add(MongoCredential.createMongoX509Credential());
       } else {
         log.info("Using an unencrypted connection to Mongo");

--- a/src/main/java/com/dawsonsystems/session/MongoManager.java
+++ b/src/main/java/com/dawsonsystems/session/MongoManager.java
@@ -477,6 +477,7 @@ public class MongoManager implements Manager, Lifecycle {
 
       BasicDBObject dbsession = new BasicDBObject();
       dbsession.put("_id", standardsession.getId());
+      dbsession.put("principalId", standardsession.getAttribute("SESSION_APPTEGIC_PRINCIPAL"));
       dbsession.put("data", data);
       if (localHostName != null) {
         dbsession.put("lasthost", localHostName);


### PR DESCRIPTION
Adds a boolean property `sslInvalidHostNameAllowed` which can allow invalid hostnames during SSL authentication.

Upgrades Java driver to a recent 3.12.x publicly released MongoDB build.